### PR TITLE
libxl: Fix compilation Warnings causing build failure when building w…

### DIFF
--- a/patches.libxl/0001-tools-include-sys-sysmacros.h-on-Linux.patch
+++ b/patches.libxl/0001-tools-include-sys-sysmacros.h-on-Linux.patch
@@ -1,0 +1,51 @@
+From 796dea37fb229c34740f98bf80f3263d7a4e3c6d Mon Sep 17 00:00:00 2001
+From: Olaf Hering <olaf@aepfle.de>
+Date: Wed, 15 Mar 2017 07:01:34 +0000
+Subject: [PATCH] tools: include sys/sysmacros.h on Linux
+
+Due to a bug in the glibc headers the macros makedev(), major() and
+minor() where avaialble by including sys/types.h. This bug was
+addressed in glibc-2.25 by introducing a warning when these macros are
+used. Since Xen is build with -Werror this new warning cause a compile
+error.
+
+Use sys/sysmacros.h to define these three macros.
+
+blktap2 is already Linux specific. The kernel header which was used to
+get makedev() does not provided it anymore, and it was wrong to use a
+kernel header anyway.
+
+Signed-off-by: Olaf Hering <olaf@aepfle.de>
+Acked-by: Wei Liu <wei.liu2@citrix.com>
+---
+ tools/blktap2/control/tap-ctl-allocate.c | 1 +
+ tools/libxl/libxl_osdeps.h               | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/tools/blktap2/control/tap-ctl-allocate.c b/tools/blktap2/control/tap-ctl-allocate.c
+index 8a6471e..187cadc 100644
+--- a/tools/blktap2/control/tap-ctl-allocate.c
++++ b/tools/blktap2/control/tap-ctl-allocate.c
+@@ -33,6 +33,7 @@
+ #include <string.h>
+ #include <getopt.h>
+ #include <libgen.h>
++#include <sys/sysmacros.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ #include <sys/ioctl.h>
+diff --git a/tools/libxl/libxl_osdeps.h b/tools/libxl/libxl_osdeps.h
+index d9661c9..1837c01 100644
+--- a/tools/libxl/libxl_osdeps.h
++++ b/tools/libxl/libxl_osdeps.h
+@@ -34,6 +34,7 @@
+ #define SYSFS_PCI_DEV          "/sys/bus/pci/devices"
+ #define SYSFS_PCIBACK_DRIVER   "/sys/bus/pci/drivers/pciback"
+ #define NETBACK_NIC_NAME       "vif%u.%d"
++#include <sys/sysmacros.h>
+ #include <pty.h>
+ #elif defined(__sun__)
+ #include <stropts.h>
+-- 
+2.5.5
+

--- a/series-vm.conf
+++ b/series-vm.conf
@@ -9,6 +9,7 @@ patches.misc/0101-libvchan-create-xenstore-entries-in-one-transaction.patch
 patches.misc/0001-libxc-prefer-using-privcmd-character-device.patch
 patches.misc/0001-tools-hotplug-Add-native-systemd-xendriverdomain.ser.patch
 patches.libxl/0001-libxl-trigger-attach-events-for-devices-attached-bef.patch
+patches.libxl/0001-tools-include-sys-sysmacros.h-on-Linux.patch
 patches.misc/0001-systemd-use-standard-dependencies-for-xendriverdomai.patch
 patches.misc/0001-libfsimage-replace-deprecated-readdir_r-with-readdir.patch
 patches.misc/0001-libxl-replace-deprecated-readdir_r-with-readdir.patch


### PR DESCRIPTION
Due to a bug in the glibc headers the macros makedev(), major() and
minor() where avaialble by including sys/types.h. This bug was
addressed in glibc-2.25 by introducing a warning when these macros are
used. Since Xen is build with -Werror this new warning cause a compile
error.